### PR TITLE
fix: overwrite enable themes

### DIFF
--- a/tutordistro/distro/themes/infraestructure/theme_git_repository.py
+++ b/tutordistro/distro/themes/infraestructure/theme_git_repository.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-
+import shutil
 import click
 
 from tutordistro.distro.themes.domain.theme_repository import ThemeRepository
@@ -21,7 +21,8 @@ class ThemeGitRepository(ThemeRepository):
                 if not click.confirm(f"Do you want to overwrite \
                 {theme_settings.get_full_directory}? "):
                     raise CloneException()
-
+                else:
+                    shutil.rmtree(f"{theme_settings.get_full_directory}")
             subprocess.call(
                 [
                     "git",


### PR DESCRIPTION
This PR is to fix bug with overwrite when run command `tutor distro enable-themes`

### How to test

1. init limonero project 
2. go to branch `jhp/fix-overwrite-enable-themes` in tutor-contrib-edunext-distro
3. run command `tutor distro enable-themes`
4. say YES when it asked you if you want to overwrite existing folder