### PR TITLE
feat: add eox-hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ and a ready to deploy in local or in development openedx distribution.
 This can be watch like a tutor-plugin but is taken a little bit far away.
 
 ## Installation
-`pip install git+https://github.com/eduNEXT/tutor-contrib-edunext-distro@v1.0.0`
+`pip install git+https://github.com/eduNEXT/tutor-contrib-edunext-distro@v2.0.0`
 
 ## Usage
 ```bash
@@ -18,8 +18,8 @@ This plugin works with some docker images. These are defined by default
 if you have different images that aren't based on these, you can have some problems.
 
 ```yaml
-DOCKER_IMAGE_OPENEDX: "docker.io/ednxops/distro-edunext-edxapp:vL.mango.1.0"
-DOCKER_IMAGE_OPENEDX_DEV: "docker.io/ednxops/distro-edunext-edxapp-dev:vL.mango.1.0"
+DOCKER_IMAGE_OPENEDX: "docker.io/ednxops/distro-edunext-edxapp:mango"
+DOCKER_IMAGE_OPENEDX_DEV: "docker.io/ednxops/distro-edunext-edxapp-dev:mango"
 ```
 
 Also, you need an edx-platform version distro compatible.
@@ -52,7 +52,7 @@ These packages will be installed in a default installation.
 In your config.yml you can set any package following this structure:
 
 ```yaml
-DISTSRO_MY_PACKAGE_NAME_DPKG:
+DISTRO_MY_PACKAGE_NAME_DPKG:
   index: git
   name: eox-package # directory name
   # ---- git package variables
@@ -154,7 +154,7 @@ compile statics and run the command `tutor local init && tutor local start` agai
 2. You should run the next command:
 ```bash
 export DOCKER_BUILDKIT=1
-tutor images build -a BUILDKIT_INLINE_CACHE=1 --docker-arg="--cache-from" --docker-arg="ednxops/distro-edunext-edxapp:vL.mango.1.0" -a EDX_PLATFORM_REPOSITORY=https://github.com/eduNEXT/edunext-platform.git -a EDX_PLATFORM_VERSION=ednx-release/mango.master openedx
+tutor images build -a BUILDKIT_INLINE_CACHE=1 --docker-arg="--cache-from" --docker-arg="ednxops/distro-edunext-edxapp:mango" -a EDX_PLATFORM_REPOSITORY=https://github.com/eduNEXT/edunext-platform.git -a EDX_PLATFORM_VERSION=ednx-release/mango.master openedx
 ```
 If you are using another edx-platform you should change it in the commando.
 

--- a/tutordistro/plugin.py
+++ b/tutordistro/plugin.py
@@ -107,6 +107,34 @@ config = {
             },
             "private": False,
         },
+        "EOX_HOOKS_DPKG": {
+            "index": "git",
+            "name": "eox-hooks",
+            "repo": "eox-hooks",
+            "version": "v2.0.1",
+            "domain": "github.com",
+            "protocol": "https",
+            "path": "eduNEXT",
+            "variables": {
+                "development": {
+                    "EOX_HOOKS_ENROLLMENTS_BACKEND": "eox_hooks.edxapp_wrapper.backends"
+                                                     ".enrollments_l_v1",
+                    "EOX_HOOKS_COURSES_BACKEND": "eox_hooks.edxapp_wrapper.backends.courses_l_v1",
+                    "EOX_HOOKS_COURSE_MODES_BACKEND": "eox_hooks.edxapp_wrapper.backends"
+                                                      ".course_modes_l_v1",
+                    "EOX_HOOKS_MODELS_BACKEND": "eox_hooks.edxapp_wrapper.backends.models_l_v1",
+                },
+                "production": {
+                    "EOX_HOOKS_ENROLLMENTS_BACKEND": "eox_hooks.edxapp_wrapper.backends"
+                                                     ".enrollments_l_v1",
+                    "EOX_HOOKS_COURSES_BACKEND": "eox_hooks.edxapp_wrapper.backends.courses_l_v1",
+                    "EOX_HOOKS_COURSE_MODES_BACKEND": "eox_hooks.edxapp_wrapper.backends"
+                                                      ".course_modes_l_v1",
+                    "EOX_HOOKS_MODELS_BACKEND": "eox_hooks.edxapp_wrapper.backends.models_l_v1",
+                },
+            },
+            "private": False,
+        },
         "EOX_TAGGING_DPKG": {
             "index": "git",
             "name": "eox-tagging",
@@ -152,8 +180,8 @@ config = {
     },
     "unique": {},
     "overrides": {
-        "DOCKER_IMAGE_OPENEDX": "docker.io/ednxops/distro-edunext-edxapp:vM.mango.1.0",
-        "DOCKER_IMAGE_OPENEDX_DEV": "docker.io/ednxops/distro-edunext-edxapp-dev:vM.mango.1.0",
+        "DOCKER_IMAGE_OPENEDX": "docker.io/ednxops/distro-edunext-edxapp:mango",
+        "DOCKER_IMAGE_OPENEDX_DEV": "docker.io/ednxops/distro-edunext-edxapp-dev:mango",
         "EDX_PLATFORM_REPOSITORY": "https://github.com/eduNEXT/edunext-platform.git",
         "EDX_PLATFORM_VERSION": "ednx-release/mango.master",
     },


### PR DESCRIPTION
# Description
These commits are to:
- Add eox-hooks 2.0.1: this didn't change because it works with maple.
- Rename images: we decided to use a naming similar to ubuntu docker images.

# Info
Ubuntu Docker Images: https://hub.docker.com/_/ubuntu?tab=tags