### PR TITLE
feat(DS-263): add an option to disable default MFE

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,5 +196,14 @@ DISTRO_EXTRA_MIDDLEWARES:
 - middleware.test.2
 ```
 
+## How disable MFE
+
+You can disable MFE default redirections and use the legacy frontend in nuez release adding in config.yml:
+
+```yaml
+DISTRO_DISABLE_MFE: true
+```
+Remember don't install tutor-mfe.
+
 # License
 This software is licensed under the terms of the AGPLv3.

--- a/tutordistro/plugin.py
+++ b/tutordistro/plugin.py
@@ -44,6 +44,7 @@ config = {
         "THEMES_NAME": [],
         "THEMES": [],
         "INSTALL_EDNX_REQUIREMENTS": False,
+        "DISTRO_DISABLE_MFE": False
     },
     "unique": {},
     "overrides": {
@@ -56,7 +57,12 @@ config = {
 
 ################# Initialization tasks
 # To run the script from templates/distro/tasks/myservice/init, add:
-
+hooks.Filters.COMMANDS_INIT.add_item(
+    (
+        "lms",
+        ("distro", "tasks", "lms", "init"),
+    )
+)
 
 # Plugin templates
 hooks.Filters.ENV_TEMPLATE_ROOTS.add_item(

--- a/tutordistro/templates/distro/tasks/lms/init
+++ b/tutordistro/templates/distro/tasks/lms/init
@@ -1,0 +1,8 @@
+{% if DISTRO_DISABLE_MFE %}
+(./manage.py lms waffle_flag --list | grep course_home.course_home_use_legacy_frontend) || ./manage.py lms waffle_flag --create --everyone course_home.course_home_use_legacy_frontend
+(./manage.py lms waffle_flag --list | grep courseware.use_legacy_frontend) || ./manage.py lms waffle_flag --create --everyone courseware.use_legacy_frontend
+
+{% else %}
+./manage.py lms waffle_delete --flags course_home.course_home_use_legacy_frontend
+./manage.py lms waffle_delete --flags courseware.use_legacy_frontend
+{% endif %}


### PR DESCRIPTION
# Add an option to disable the default MFE

## Description
This PR creates a variable `DISTRO_DISABLE_MFE` to add waffle flags and use the frontend legacy (courseware).

By default  `DISTRO_DISABLE_MFE`  is false. 

## How to test

- Create an environment with stack builder and  Distro (this branch), with `strain create` and:
```yml
STRAIN_NAME: distromfe
STRAIN_TUTOR_VERSION: v14.0.1
DEV_PROJECT_NAME: distromfe_dev
LOCAL_PROJECT_NAME: distromfe_local
STRAIN_TUTOR_PLUGINS:
  - REPO: tutor-contrib-edunext-distro
    VERSION: dcoa/disable-mfe-nuez
    EGG: tutor-contrib-edunext-distro==v3.0.0
    PACKAGE_NAME: distro
    PROTOCOL: ssh
DISTRO_DISABLE_MFE: true
CMS_HOST: studio.nutmeg.edunext.link
LMS_HOST: lms.nutmeg.edunext.link
```
- run `stack strain <local | dev> configure` to install plugin distro. 
- run `stack strain <local | dev> init` , this step create the flags.
You can see in the logs something like 
![create_pluging_flag](https://user-images.githubusercontent.com/66016493/195725960-f8017549-cdd6-4bdb-91cb-6e741064b9d3.png)
- Create a superuser `tutor <local | dev > createuser --staff --superuser admin admin@edunext.co` and import demo_course `tutor <local | dev> importdemocourse`
- If you verify the Django admin `/admin/waffle/flag/` you can see the waffle flags created.
- If you navigate the demo course you see the legacy frontend.

if you configure `DISTRO_DISABLE_MFE: false` and re-run  `stack strain <local | dev> init` the flags have to be removed. 