### PR TITLE
fix: olive compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ from a public repository, for it works you should run the command to clone priva
 tutor distro enable-private-packages
 ```
 
-- **local**: It will be necessary to build a new image and run the command tutor local init && tutor local start again.
-- **dev**: you must run the command tutor dev init && tutor dev start again.
+- **local**: It will be necessary to build a new image and run the command tutor local do init && tutor local start again.
+- **dev**: you must run the command tutor dev do init && tutor dev start again.
 
 ## How to override a default package
 
@@ -182,8 +182,8 @@ tutor distro enable-themes
 ```
 
 - **local**: you must build a new image to add the new themes and
-  compile statics and run the command `tutor local init && tutor local start` again.
-- **dev**: you must run the command `tutor dev init && tutor dev start` again.
+  compile statics and run the command `tutor local do init && tutor local start` again.
+- **dev**: you must run the command `tutor dev do init && tutor dev start` again.
   - **since tutor 13.0.0** you should recompile statics in the container, you could run the next command to do it:
   ```bash
   openedx-assets themes --theme-dirs THEME_DIRS --themes THEME_NAMES

--- a/docs/how_to_add_new_packages.rst
+++ b/docs/how_to_add_new_packages.rst
@@ -90,11 +90,11 @@ Use your new packages
 To use in local mode:
 
 1. Build the docker image.
-2. Run ``tutor local init``
+2. Run ``tutor local do init``
 3. Run ``tutor local start``
 
 
 To use in dev mode:
 
-1. Run ``tutor dev init``
+1. Run ``tutor dev do init``
 2. Run ``tutor dev start``

--- a/tutordistro/plugin.py
+++ b/tutordistro/plugin.py
@@ -163,14 +163,6 @@ config = {
     },
 }
 
-################# Initialization tasks
-# To run the script from templates/distro/tasks/myservice/init, add:
-hooks.Filters.COMMANDS_INIT.add_item(
-    (
-        "lms",
-        ("distro", "tasks", "lms", "init"),
-    )
-)
 
 # Plugin templates
 hooks.Filters.ENV_TEMPLATE_ROOTS.add_item(


### PR DESCRIPTION
### Fix init error with olive

When try to run `init` command, this fails with the following error:

![image](https://user-images.githubusercontent.com/66016493/225837971-652073d6-d72e-4ba1-a533-5751fb333fed.png)

The error is generated by [this line](https://github.com/eduNEXT/tutor-contrib-edunext-distro/pull/31/files#diff-d4208f76d126d3e85f18d0c63e44136e9e107df5a2f2b05e58624616e68fa893R60) part of the MFE feature which had been removed to olive. 
In addition update the docs init command reference according with the tutor documentation: 
https://docs.tutor.overhang.io/local.html#service-initialisation