### PR TITLE
fix: add condition to validate if element "variable" exists

### DIFF
--- a/tutordistro/patches/openedx-cms-development-settings
+++ b/tutordistro/patches/openedx-cms-development-settings
@@ -1,9 +1,11 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
+{%- if "variable" in pkg -%}
 {%- for key, value in pkg["variables"]["development"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %}
 {%- endfor %}
+{%- endif -%}
 # End {{ pkg["name"] }} settings
 {%- endif -%}
 {% endfor %}

--- a/tutordistro/patches/openedx-cms-development-settings
+++ b/tutordistro/patches/openedx-cms-development-settings
@@ -1,7 +1,7 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
-{%- if "variable" in pkg -%}
+{%- if "variables" in pkg and "development" in pkg["variables"] -%}
 {%- for key, value in pkg["variables"]["development"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %}
 {%- endfor %}

--- a/tutordistro/patches/openedx-cms-production-settings
+++ b/tutordistro/patches/openedx-cms-production-settings
@@ -1,9 +1,11 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
+{%- if "variable" in pkg -%}
 {%- for key, value in pkg["variables"]["production"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %}
 {%- endfor %}
+{%- endif -%}
 # End {{ pkg["name"] }} settings
 {%- endif -%}
 {% endfor %}

--- a/tutordistro/patches/openedx-cms-production-settings
+++ b/tutordistro/patches/openedx-cms-production-settings
@@ -1,7 +1,7 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
-{%- if "variable" in pkg -%}
+{%- if "variables" in pkg and "production" in pkg["variables"] -%}
 {%- for key, value in pkg["variables"]["production"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %}
 {%- endfor %}

--- a/tutordistro/patches/openedx-common-assets-settings
+++ b/tutordistro/patches/openedx-common-assets-settings
@@ -1,7 +1,7 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
-{%- if "variable" in pkg -%}
+{%- if "variables" in pkg and "development" in pkg["variables"] -%}
 {%- for key, value in pkg["variables"]["development"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %} 
 {%- endfor %}

--- a/tutordistro/patches/openedx-common-assets-settings
+++ b/tutordistro/patches/openedx-common-assets-settings
@@ -1,10 +1,12 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
+{%- if "variable" in pkg -%}
 {%- for key, value in pkg["variables"]["development"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %} 
 {%- endfor %}
 # End {{ pkg["name"] }} settings
+{%- endif -%}
 {%- endif -%}
 {% endfor %}
 

--- a/tutordistro/patches/openedx-common-i18n-settings
+++ b/tutordistro/patches/openedx-common-i18n-settings
@@ -1,7 +1,7 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
-{%- if "variable" in pkg -%}
+{%- if "variables" in pkg and "development" in pkg["variables"] -%}
 {%- for key, value in pkg["variables"]["development"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %} 
 {%- endfor %}

--- a/tutordistro/patches/openedx-common-i18n-settings
+++ b/tutordistro/patches/openedx-common-i18n-settings
@@ -1,9 +1,11 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
+{%- if "variable" in pkg -%}
 {%- for key, value in pkg["variables"]["development"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %} 
 {%- endfor %}
 # End {{ pkg["name"] }} settings
+{%- endif -%}
 {%- endif -%}
 {% endfor %}

--- a/tutordistro/patches/openedx-development-settings
+++ b/tutordistro/patches/openedx-development-settings
@@ -1,7 +1,7 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
-{%- if "variable" in pkg -%}
+{%- if "variables" in pkg and "development" in pkg["variables"] -%}
 {%- for key, value in pkg["variables"]["development"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %} 
 {%- endfor %}

--- a/tutordistro/patches/openedx-development-settings
+++ b/tutordistro/patches/openedx-development-settings
@@ -1,10 +1,12 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
+{%- if "variable" in pkg -%}
 {%- for key, value in pkg["variables"]["development"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %} 
 {%- endfor %}
 # End {{ pkg["name"] }} settings
+{%- endif -%}
 {%- endif -%}
 {% endfor %}
 

--- a/tutordistro/patches/openedx-lms-production-settings
+++ b/tutordistro/patches/openedx-lms-production-settings
@@ -1,10 +1,12 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
+{%- if "variable" in pkg -%}
 {%- for key, value in pkg["variables"]["production"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %} 
 {%- endfor %}
 # End {{ pkg["name"] }} settings
+{%- endif -%}
 {%- endif -%}
 {% endfor %}
 

--- a/tutordistro/patches/openedx-lms-production-settings
+++ b/tutordistro/patches/openedx-lms-production-settings
@@ -1,7 +1,7 @@
 {% for pkg in iter_values_named(suffix="_DPKG") %}
 {%- if pkg != 'None' -%}
 # Start {{ pkg["name"] }} settings
-{%- if "variable" in pkg -%}
+{%- if "variables" in pkg and "production" in pkg["variables"] -%}
 {%- for key, value in pkg["variables"]["production"].items() %}
 {{ key }} = {% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %} 
 {%- endfor %}

--- a/tutordistro/plugin.py
+++ b/tutordistro/plugin.py
@@ -79,10 +79,6 @@ config = {
             "domain": "github.com",
             "protocol": "https",
             "path": "eduNEXT",
-            "variables": {
-                "development": {},
-                "production": {},
-            },
             "EOX_THEMING_CONFIG_SOURCES":[
                 "from_eox_tenant_microsite_v2",
                 "from_django_settings"
@@ -97,10 +93,6 @@ config = {
             "domain": "github.com",
             "protocol": "https",
             "path": "eduNEXT",
-            "variables": {
-                "development": {},
-                "production": {},
-            },
             "private": False,
         },
         "EOX_TAGGING_DPKG": {
@@ -111,10 +103,6 @@ config = {
             "domain": "github.com",
             "protocol": "https",
             "path": "eduNEXT",
-            "variables": {
-                "development": {},
-                "production": {},
-            },
             "private": False,
         },
        "EOX_AUDIT_MODEL_DPKG": {
@@ -125,12 +113,6 @@ config = {
             "domain": "github.com",
             "protocol": "https",
             "path": "eduNEXT",
-            "variables": {
-                "development": {
-                },
-                "production": {
-                },
-            },
             "private": False,
         },
         "THEMES_ROOT": "/openedx/themes",


### PR DESCRIPTION
# Description

This PR fixes  the following error:  If a package is added without variables this will raise the following error
![190263652-8c1c3d90-b952-4e7d-80ea-8a96d631264d](https://user-images.githubusercontent.com/78836902/232159402-5b4be3eb-3b0d-44c0-bd82-b60cf53f64a1.png)

# How to test

-  enabling distro plugin

`pip install git+https://github.com/eduNEXT/tutor-contrib-edunext-distro.git@DS-481`
`tutor plugins enable distro`

-  remove package variables: tutor-contrib-edunext-distro/tutordistro/plugin.py

Example:
`"EOX_THEMING_DPKG": {
            "index": "git",
            "name": "eox-theming",
            "repo": "eox-theming",
            "version": "v5.0.0",
            "domain": "github.com",
            "protocol": "https",
            "path": "eduNEXT",
            "EOX_THEMING_CONFIG_SOURCES":[
                "from_eox_tenant_microsite_v2",
                "from_django_settings"
            ],
            "private": False,
        },`

-  saving the config changes

`tutor config save`