### PR TITLE
fix: wrong CMS development settings

### DIFF
--- a/tutordistro/patches/openedx-cms-development-settings
+++ b/tutordistro/patches/openedx-cms-development-settings
@@ -9,3 +9,14 @@
 # End {{ pkg["name"] }} settings
 {%- endif -%}
 {% endfor %}
+
+{%- for pkg in iter_values_named(suffix="_DPKG") %}
+{%- if pkg["name"] == 'eox-theming' %}
+################## EOX_THEMING ##################
+from lms.envs.common import _make_mako_template_dirs # pylint: disable=import-error
+ENABLE_COMPREHENSIVE_THEMING = True
+TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
+derive_settings("cms.envs.devstack")
+# EOL
+{%- endif %}
+{%- endfor %}

--- a/tutordistro/patches/openedx-development-settings
+++ b/tutordistro/patches/openedx-development-settings
@@ -15,18 +15,6 @@ COMPREHENSIVE_THEME_DIRS.remove('/openedx/themes')
 COMPREHENSIVE_THEME_DIRS.extend({{ DISTRO_THEME_DIRS }})
 {%- endif %}
 
-{%- for pkg in iter_values_named(suffix="_DPKG") %}
-{%- if pkg["name"] == 'eox-theming' %}
-################## EOX_THEMING ##################
-if "EOX_THEMING_DEFAULT_THEME_NAME" in locals() and EOX_THEMING_DEFAULT_THEME_NAME:
-    from lms.envs.common import _make_mako_template_dirs # pylint: disable=import-error
-    ENABLE_COMPREHENSIVE_THEMING = True
-    TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
-    derive_settings("lms.envs.devstack")
-# EOL
-{%- endif %}
-{%- endfor %}
-
 {%- if DISTRO_EXTRA_MIDDLEWARES is defined %}
 MIDDLEWARE.extend({{ DISTRO_EXTRA_MIDDLEWARES }})
 {% endif %}

--- a/tutordistro/patches/openedx-lms-development-settings
+++ b/tutordistro/patches/openedx-lms-development-settings
@@ -1,1 +1,14 @@
 SESSION_COOKIE_DOMAIN = ".{{ LMS_HOST|common_domain(CMS_HOST) }}"
+
+{%- for pkg in iter_values_named(suffix="_DPKG") %}
+{%- if pkg["name"] == 'eox-theming' %}
+################## EOX_THEMING ##################
+if "EOX_THEMING_DEFAULT_THEME_NAME" in locals() and EOX_THEMING_DEFAULT_THEME_NAME:
+    from lms.envs.common import _make_mako_template_dirs # pylint: disable=import-error
+    ENABLE_COMPREHENSIVE_THEMING = True
+    TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
+    derive_settings("lms.envs.devstack")
+    
+# EOL
+{%- endif %}
+{%- endfor %}


### PR DESCRIPTION
## Description

This PR fixes the following bug: https://github.com/eduNEXT/tutor-contrib-edunext-distro/issues/35

## Testing instructions

In a Tutor Olive (15.3.9) environment run:

`git clone -b lfc/DS-506 git@github.com:eduNEXT/tutor-contrib-edunext-distro.git`
`pip install tutor-contrib-edunext-distro`
`tutor plugins enable distro`

Adds in your config.yml file something like:
  ``` yml
  DISTRO_EOX_TENANT_DPKG:
    domain: github.com
    index: git
    name: eox-tenant
    path: eduNEXT
    private: false
    protocol: https
    repo: eox-tenant
    variables:
      development:
        EOX_TENANT_LOAD_PERMISSIONS: false
        EOX_TENANT_USERS_BACKEND: eox_tenant.edxapp_wrapper.backends.users_l_v1
      production:
        EOX_TENANT_LOAD_PERMISSIONS: false
        EOX_TENANT_USERS_BACKEND: eox_tenant.edxapp_wrapper.backends.users_l_v1
    version: v8.0.0
  DISTRO_EOX_THEMING_DPKG:
    domain: github.com
    index: git
    name: eox-theming
    path: eduNEXT
    private: false
    protocol: https
    repo: eox-theming
    variables:
      development:
        EOX_THEMING_CONFIG_SOURCES:
        - from_eox_tenant_microsite_v2
        - from_django_settings
        EOX_THEMING_DEFAULT_THEME_NAME: bragi
      production:
        EOX_THEMING_CONFIG_SOURCES:
        - from_eox_tenant_microsite_v2
        - from_django_settings
        EOX_THEMING_DEFAULT_THEME_NAME: bragi
    version: v5.0.0
  DISTRO_THEMES:
  - domain: github.com
    name: ednx-saas-themes
    path: eduNEXT
    protocol: ssh
    repo: ednx-saas-themes
    version: edunext/olmo.master
  DISTRO_THEMES_NAME:
  - bragi
  DISTRO_THEMES_ROOT: /openedx/themes
  DISTRO_THEME_DIRS:
  - /openedx/themes/ednx-saas-themes/edx-platform
  - /openedx/themes/ednx-saas-themes/edx-platform/bragi-children
  - /openedx/themes/ednx-saas-themes/edx-platform/bragi-generator
```

And:

`tutor distro enable-themes`
`tutor config save`
`tutor dev start`

In Site (http://local.overhang.io:8000/admin/sites/site/):
Add site:  studio.local.overhang.io:8001

In Site Configuration (http://local.overhang.io:8000/admin/site_configuration/siteconfiguration/)
```
{
    "STUDIO_LOGO_URL": "http://local.overhang.io:8000/static/bragi/images/logo.png",
    "STUDIO_NAME": "studio test"
}
```
You can see the edunext logo

![image](https://github.com/eduNEXT/tutor-contrib-edunext-distro/assets/78836902/7e10df17-0a37-4dbd-855c-49500bc61626)
