### PR TITLE
refactor: validate repos with git commands & improve readability

### DIFF
--- a/tutordistro/distro/packages/infrastructure/package_git_repository.py
+++ b/tutordistro/distro/packages/infrastructure/package_git_repository.py
@@ -52,6 +52,7 @@ class PackageGitRepository(PackageRepository):
             package (Package): The package to be cloned.
             path (str): The destination path for cloning the package.
         """
+        repo = None
         if "https" == package.extra["protocol"]:
             repo = (
                 f"https://{package.domain}/"

--- a/tutordistro/distro/repository_validator/infrastructure/git_package_repository.py
+++ b/tutordistro/distro/repository_validator/infrastructure/git_package_repository.py
@@ -5,6 +5,8 @@ It interacts with a Git repository to validate a CloudPackage.
 """
 
 
+from __future__ import annotations
+
 import subprocess
 from typing import Optional
 

--- a/tutordistro/distro/repository_validator/infrastructure/git_package_repository.py
+++ b/tutordistro/distro/repository_validator/infrastructure/git_package_repository.py
@@ -5,7 +5,8 @@ It interacts with a Git repository to validate a CloudPackage.
 """
 
 
-import requests
+import subprocess
+from typing import Optional
 
 from tutordistro.distro.share.domain.cloud_package import CloudPackage
 from tutordistro.distro.share.domain.cloud_package_repository import CloudPackageRepository
@@ -16,10 +17,69 @@ class GitPackageRepository(CloudPackageRepository):
     """
     Repository class for validating CloudPackages using a Git repository.
 
-    It inherits from CloudPackageRepository and provides the implementation for
-    the validation method.
+    This class inherits from CloudPackageRepository and provides the implementation for
+    the validation method. It verifies the existence of the repository and checks
+    if the specified branch or tag exists.
     """
     def validate(self, package: CloudPackage) -> None:
-        response = requests.get(package.to_url(), timeout=5)
-        if response.status_code != 200:
-            raise PackageDoesNotExist(f"The package {package.name} or branch doesn't exist or is private")
+        package_url = package.to_url()
+        repo_url, version_name = self._parse_package_url(package_url)
+
+        self._verify_repository_exists(repo_url)
+        if version_name:
+            self._verify_version_exists(repo_url, version_name)
+
+    def _parse_package_url(self, package_url: str) -> tuple[str, Optional[str]]:
+        """
+        Parse the package URL to extract the repository URL and the version name.
+
+        Args:
+            package_url (str): The full URL of the package.
+
+        Returns:
+            tuple: A tuple containing the repository URL and the version name (branch/tag).
+        """
+        split_url = package_url.split('/tree/')
+        repo_url = split_url[0]
+        version_name = split_url[1] if len(split_url) > 1 else None
+        return repo_url, version_name
+
+    def _verify_repository_exists(self, repo_url: str) -> None:
+        """
+        Verify that the repository exists.
+
+        Args:
+            repo_url (str): The URL of the repository.
+
+        Raises:
+            PackageDoesNotExist: If the repository does not exist or is private.
+        """
+        result = subprocess.run(
+            ['git', 'ls-remote', repo_url],
+            capture_output=True, text=True, check=False
+        )
+        if result.returncode != 0:
+            raise PackageDoesNotExist(f'The package "{repo_url}" does not exist or is private')
+
+    def _verify_version_exists(self, repo_url: str, version_name: str) -> None:
+        """
+        Verify that the branch or tag exists in the repository.
+
+        Args:
+            repo_url (str): The URL of the repository.
+            version_name (str): The branch or tag name to verify.
+
+        Raises:
+            PackageDoesNotExist: If neither the branch nor the tag exists.
+        """
+        branch_result = subprocess.run(
+            ['git', 'ls-remote', '--heads', repo_url, version_name],
+            capture_output=True, text=True, check=False
+        )
+        tag_result = subprocess.run(
+            ['git', 'ls-remote', '--tags', repo_url, version_name],
+            capture_output=True, text=True, check=False
+        )
+
+        if not branch_result.stdout and not tag_result.stdout:
+            raise PackageDoesNotExist(f'Neither branch nor tag "{version_name}" exists on "{repo_url}"')

--- a/tutordistro/distro/themes/infraestructure/theme_git_repository.py
+++ b/tutordistro/distro/themes/infraestructure/theme_git_repository.py
@@ -32,6 +32,7 @@ class ThemeGitRepository(ThemeRepository):
         Args:
             theme_settings (ThemeSettings): Theme settings.
         """
+        repo = None
         if "https" == theme_settings.settings["protocol"]:
             repo = (
                 f"https://{theme_settings.settings['domain']}/"


### PR DESCRIPTION
## Description
This PR aims to fix the issue #63 where the repository validator command failed incorrectly.

### How to test
- Have a Quince environment and install this branch: `pip install git+https://github.com/eduNEXT/tutor-contrib-edunext-distro@bc/fix-repo-validations`
- Add in the config.yml
```yml
OPENEDX_EXTRA_PIP_REQUIREMENTS:
- git+https://github.com/eduNEXT/no-existing-repo
- git+https://github.com/eduNEXT/edx-ora2@no-existing-branch#egg=ora2==5.5.7
```
- Run the command of validation: `tutor distro repository-validator`

Note: Should not show an error if the thing after `@` is a valid branch or a valid tag.

### Evidence
![image](https://github.com/eduNEXT/tutor-contrib-edunext-distro/assets/86393372/fc1c8126-66ab-465e-a8e5-0d58d663bede)


[JIRA ISSUE DS-939](https://edunext.atlassian.net/browse/DS-939)