### PR TITLE
perf: add redwood compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## v18.0.0 - 2024-06-27
+
+### [18.0.0](https://github.com/eduNEXT/tutor-contrib-edunext-distro/compare/v17.2.0...v18.0.0) (2024-06-27)
+
+#### ⚠ BREAKING CHANGES
+
+* Add support to Redwood ([885e0b9](https://github.com/eduNEXT/tutor-contrib-edunext-distro/commit/885e0b955722e4d86f89547764537ee74f707cf9)); the main change 
+
+* Fix when 'tutor distro enable-themes' was executed before, a new execution hung when it tried to overwrite the existing theme folder. The process requires confirmation ('yes') to proceed with the overwrite, but it did not receive this input automatically, leading to a freeze ([1924007](https://github.com/eduNEXT/tutor-contrib-edunext-distro/commit/1924007d121b46c9dc5949810f1e7f89fdf0fad2))
+
 ## v17.2.0 - 2024-04-05
 
 ### [17.2.0](https://github.com/eduNEXT/tutor-contrib-edunext-distro/compare/v17.1.0...v17.2.0) (2024-04-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### ⚠ BREAKING CHANGES
 
-* Add support to Redwood ([885e0b9](https://github.com/eduNEXT/tutor-contrib-edunext-distro/commit/885e0b955722e4d86f89547764537ee74f707cf9)); the main change 
+* [Feature] Add support to Redwood ([885e0b9](https://github.com/eduNEXT/tutor-contrib-edunext-distro/commit/885e0b955722e4d86f89547764537ee74f707cf9))
 
-* Fix when 'tutor distro enable-themes' was executed before, a new execution hung when it tried to overwrite the existing theme folder. The process requires confirmation ('yes') to proceed with the overwrite, but it did not receive this input automatically, leading to a freeze ([1924007](https://github.com/eduNEXT/tutor-contrib-edunext-distro/commit/1924007d121b46c9dc5949810f1e7f89fdf0fad2))
+* [Bugfix] Adapt the inline Tutor plugin `openedx-dockerfile-pre-assets` to stop using the deprecated command [openedx-assets](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1800-2024-06-19:~:text=%F0%9F%92%A5%5BFeature%5D%20The%20openedx,or%20cms%20container%3A) for setting the pre-assets of the custom themes added with Distro ([885e0b9](https://github.com/eduNEXT/tutor-contrib-edunext-distro/commit/885e0b955722e4d86f89547764537ee74f707cf9#diff-d32c8a1ee8b6076c6fb3375498a9d455d41cad3104464e9b1e3900fd4265160a))
+
+* [Bugfix] 'tutor distro enable-themes' command would hang when trying to overwrite an existing theme folder due to not being able to read the confirmation input ('yes') to perform the overwrite ([1924007](https://github.com/eduNEXT/tutor-contrib-edunext-distro/commit/1924007d121b46c9dc5949810f1e7f89fdf0fad2)).
 
 ## v17.2.0 - 2024-04-05
 

--- a/README.md
+++ b/README.md
@@ -237,14 +237,16 @@ tutor distro enable-themes
 > tutor images build openedx-dev
 > tutor dev do init
 > tutor dev start
-> tutor dev run lms openedx-assets themes --theme-dirs [THEME_DIRS] --themes [THEME_NAMES]
+> tutor dev exec lms bash
+> npm run compile-sass -- --theme-dir X --theme-dir Y --theme A --theme B
 > ```
 >
 > or
 >
 > ```bash
 > tutor dev launch
-> tutor dev run lms openedx-assets themes --theme-dirs [THEME_DIRS] --themes [THEME_NAMES]
+> tutor dev exec lms bash
+> npm run compile-sass -- --theme-dir X --theme-dir Y --theme A --theme B
 > ```
 
 # Commands

--- a/README.md
+++ b/README.md
@@ -64,12 +64,13 @@ Please see the following table for details on compatibility.
 | olive   | v15   |
 | palm    | v16   |
 | quince  | v17   |
+| redwood | v18   |
 
 Then, specify the docker image variables to identify your custom images, like the example:
 
 ```yaml
-DOCKER_IMAGE_OPENEDX: 'docker.io/ednxops/distro-edunext-edxapp:quince'
-DOCKER_IMAGE_OPENEDX_DEV: 'docker.io/ednxops/distro-edunext-edxapp-dev:quince'
+DOCKER_IMAGE_OPENEDX: "docker.io/ednxops/distro-edunext-edxapp:redwood"
+DOCKER_IMAGE_OPENEDX_DEV: "docker.io/ednxops/distro-edunext-edxapp-dev:redwood"
 ```
 
 Finally, launch your instance or build a new image to reflect the changes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 17.2.0
+current_version = 18.0.0
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor>=17.0.3, <18", "click", "schema"],
+    install_requires=["tutor>=18.0.0, <19", "click", "schema"],
     extras_require={
             "test": ["behave", "pytest", "pylint", "pytest-mock", "pycodestyle", "isort", "schema"]
         },

--- a/tutordistro/__about__.py
+++ b/tutordistro/__about__.py
@@ -2,4 +2,4 @@
 Tutor Distro version.
 """
 
-__version__ = "17.2.0"
+__version__ = "18.0.0"

--- a/tutordistro/distro/extra_commands/infrastructure/tutor_commands.py
+++ b/tutordistro/distro/extra_commands/infrastructure/tutor_commands.py
@@ -69,8 +69,6 @@ class TutorCommandManager(CommandManager):
             command (str): Tutor command.
         """
         try:
-            print(f'Running "{command}"')
-
             with subprocess.Popen(
                 command,
                 shell=True,
@@ -81,12 +79,16 @@ class TutorCommandManager(CommandManager):
                 text=True,
             ) as process:
 
+                # It is sent a 'y' to say 'yes' on overriding the existing folders
                 stdout, stderr = process.communicate(input="y")
 
                 if process.returncode != 0 or "error" in stderr.lower():
                     raise subprocess.CalledProcessError(
                         process.returncode, command, output=stdout, stderr=stderr
                     )
+
+                # This print is left on purpose to show the command output
+                print(stdout)
 
         except subprocess.CalledProcessError as error:
             raise CommandError(f"\n{error.stderr}") from error

--- a/tutordistro/distro/extra_commands/infrastructure/tutor_commands.py
+++ b/tutordistro/distro/extra_commands/infrastructure/tutor_commands.py
@@ -69,17 +69,24 @@ class TutorCommandManager(CommandManager):
             command (str): Tutor command.
         """
         try:
-            process = subprocess.run(
+            print(f'Running "{command}"')
+
+            with subprocess.Popen(
                 command,
                 shell=True,
-                check=True,
-                capture_output=True,
                 executable="/bin/bash",
-            )
-            # This print is left on purpose to show the command output
-            print(process.stdout.decode())
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            ) as process:
+
+                stdout, stderr = process.communicate(input="y")
+
+                if process.returncode != 0 or "error" in stderr.lower():
+                    raise subprocess.CalledProcessError(
+                        process.returncode, command, output=stdout, stderr=stderr
+                    )
 
         except subprocess.CalledProcessError as error:
-            raise CommandError(
-                f"Error running command '{error.cmd}':\n{error.stderr.decode()}"
-            ) from error
+            raise CommandError(f"\n{error.stderr}") from error

--- a/tutordistro/patches/openedx-dockerfile-pre-assets
+++ b/tutordistro/patches/openedx-dockerfile-pre-assets
@@ -1,16 +1,15 @@
 ENV NO_PYTHON_UNINSTALL 1
 ENV NO_PREREQ_INSTALL 1
-RUN openedx-assets xmodule \
-    && openedx-assets npm \
-    && openedx-assets webpack --env=prod \
-    && openedx-assets common
+RUN npm run postinstall \
+    && npm run webpack \
+    && npm run compile-sass -- --skip-themes
 {% if DISTRO_THEMES_ROOT is defined %}
 COPY --chown=app:app ./themes/ {{ DISTRO_THEMES_ROOT }}
 {% endif %}
 {% if DISTRO_THEME_DIRS is defined and DISTRO_THEMES_NAME is defined %}
-RUN openedx-assets themes \
-    --theme-dirs {{ DISTRO_THEME_DIRS | join(' ') }} \
-    --themes {{ DISTRO_THEMES_NAME | join(' ') }} \
-    && openedx-assets collect --settings=tutor.assets \
+RUN npm run compile-sass -- \
+    --theme-dir {{ DISTRO_THEME_DIRS | join(' --theme-dir ') }} \
+    --theme {{ DISTRO_THEMES_NAME | join(' --theme ') }} \
+    && ./manage.py lms collectstatic --noinput --settings=tutor.assets \
     && rdfind -makesymlinks true -followsymlinks true /openedx/staticfiles/
 {% endif %}


### PR DESCRIPTION
## Description

This PR aims to give Distro support to Redwood's release. Additionally, taking advantage of this maintenance effort, it was solved a found bug with the command 'enable themes' when the command was executed before, if was executed again it stayed frozen because if it was not sent a 'yes', the command could not override the previous created folder. 

## Testing instructions

- Create a Redwood environment with Tutor MFE installed and enabled
- Install Distro using this branch `pip install git+https://github.com/eduNEXT/tutor-contrib-edunext-distro@bc/add-redwood-support` and enable it `tutor plugins enable distro`
- Add this to the `config.yml` and run `tutor config save`
  ```yml
    MFE_DOCKER_IMAGE: docker.io/ednxops/ednx-mfe:redwood
    DOCKER_IMAGE_OPENEDX: docker.io/ednxops/distro-edunext-edxapp:redwood
    DISTRO_EOX_THEMING_DPKG:
      domain: github.com
      index: git
      name: eox-theming
      path: eduNEXT
      private: false
      protocol: https
      repo: eox-theming
      variables:
        development:
          EOX_THEMING_CONFIG_SOURCES:
          - from_eox_tenant_microsite_v2
          - from_django_settings
        production:
          EOX_THEMING_CONFIG_SOURCES:
          - from_eox_tenant_microsite_v2
          - from_django_settings
      version: v7.0.0
    DISTRO_EOX_MANAGE_DPKG:
      index: git
      name: eox-manage
      repo: eox-manage
      domain: github.com
      path: eduNEXT
      protocol: ssh
      private: true
      variables:
        development: {}
        production: {}
      version: v5.0.0
    DISTRO_EXTRA_COMMANDS:
    - tutor distro enable-themes
    - tutor distro enable-private-packages
    - tutor config save
    DISTRO_THEMES:
    - domain: github.com
      name: ednx-saas-themes
      path: eduNEXT
      protocol: ssh
      repo: ednx-saas-themes
      version: edunext/quince.master
    DISTRO_THEMES_NAME:
    - bragi
    - css-runtime
    DISTRO_THEMES_ROOT: /openedx/themes
    DISTRO_THEME_DIRS:
    - /openedx/themes/ednx-saas-themes/edx-platform
    - /openedx/themes/ednx-saas-themes/edx-platform/bragi-generator
    - /openedx/themes/ednx-saas-themes/edx-platform/bragi-children
  ```
- Run the commands 
  ```bash
    tutor distro syntax-validator
    tutor distro repository-validator
    tutor distro run-extra-commands
  ```
- Verify the 2 first commands ran without showing errors and for the last one verify that the commands from DISTRO_EXTRA_COMMANDS in the `config.yml` are executed properly.; in this case will be run 2 Distro commands:
  - `tutor distro enable-themes`: you should find a folder ednx-saas-themes at `env/build/openedx/themes`
  - `tutor distro enable-private-packages` you should find a folder eox-manage at `env/build/openedx/requirements`

**ADDITIONAL CASES**
  - If there is a syntax error (i.g. `DISTRO_EOX_THEMING_DPKG` is missing the `path` key & value) you should watch an error
  - If there is an error with a repository (i.g. `DISTRO_EOX_THEMING_DPKG` has the value of `repo` misspelled) you should watch an error
  - When adding many themes (in this case `bragi` and `css-runtime`) if I set a default theme (i.g. DISTRO_DEFAULT_SITE_THEME = css-runtime) in the `config.yml` then I could access it in the LMS/CMS configuration.
  - When are added extra settings or middleware following [the README](https://github.com/eduNEXT/tutor-contrib-edunext-distro?tab=readme-ov-file#other-configurations-available) they should be visible in the LMS/CMS configurations

At last, create an image with the new settings `tutor images build openedx`, and once this is finished, init the environment `tutor local do init` and start the environment in local mode `tutor local start`. To confirm everything goes as expected, besides creating the image without errors, it is important to confirm (1) that the versions of the EOXs that are installed correspond with the ones defined in the `config.yml`, accessing the container `tutor local exec lms` and watching the installed dependencies `pip list` and (2) that we can see `bragi` as the default theme.

## Additional information

[JIRA ISSUE DS-1007](https://edunext.atlassian.net/browse/DS-1007)

